### PR TITLE
Add simple PyQt5 browser example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # TestingVibe
+
+This repository contains a very minimal example of a web browser built with PyQt5. The browser provides a basic navigation bar with Back, Forward, and Reload buttons along with an address bar.
+
+## Running the browser
+
+1. Install the required packages:
+   ```bash
+   pip install PyQt5 PyQtWebEngine
+   ```
+2. Run the script:
+   ```bash
+   python simple_browser.py
+   ```
+
+The browser will open with an initial page loaded from `https://www.example.com`.

--- a/simple_browser.py
+++ b/simple_browser.py
@@ -1,0 +1,56 @@
+import sys
+from PyQt5.QtCore import QUrl
+from PyQt5.QtWidgets import QApplication, QMainWindow, QLineEdit, QToolBar, QAction
+from PyQt5.QtWebEngineWidgets import QWebEngineView
+
+
+class Browser(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('Simple Browser')
+        self.resize(1024, 768)
+
+        self.web_view = QWebEngineView()
+        self.setCentralWidget(self.web_view)
+
+        nav_bar = QToolBar()
+        self.addToolBar(nav_bar)
+
+        back_btn = QAction('Back', self)
+        back_btn.triggered.connect(self.web_view.back)
+        nav_bar.addAction(back_btn)
+
+        forward_btn = QAction('Forward', self)
+        forward_btn.triggered.connect(self.web_view.forward)
+        nav_bar.addAction(forward_btn)
+
+        reload_btn = QAction('Reload', self)
+        reload_btn.triggered.connect(self.web_view.reload)
+        nav_bar.addAction(reload_btn)
+
+        self.url_bar = QLineEdit()
+        self.url_bar.returnPressed.connect(self.navigate_to_url)
+        nav_bar.addWidget(self.url_bar)
+
+        self.web_view.urlChanged.connect(self.update_url_bar)
+        self.web_view.load(QUrl('https://www.example.com'))
+
+    def navigate_to_url(self):
+        url = QUrl(self.url_bar.text())
+        if url.scheme() == '':
+            url.setScheme('http')
+        self.web_view.load(url)
+
+    def update_url_bar(self, url):
+        self.url_bar.setText(url.toString())
+
+
+def main():
+    app = QApplication(sys.argv)
+    browser = Browser()
+    browser.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a PyQt5-based web browser example
- document how to run the browser

## Testing
- `pip install PyQt5 PyQtWebEngine`
- `python simple_browser.py` *(fails: Qt platform plugin "xcb" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ba499b18832a8509f6087ee6ae0a